### PR TITLE
changed nonexistent ExecRestart to ExecReload

### DIFF
--- a/zswap.service
+++ b/zswap.service
@@ -5,7 +5,7 @@ Description=Zram-based swap (compressed RAM block devices)
 Type=oneshot
 ExecStart=/usr/lib/systemd/scripts/zswap.sh start
 ExecStop=/usr/lib/systemd/scripts/zswap.sh stop
-ExecRestart=/usr/lib/systemd/scripts/zswap.sh restart
+ExecReload=/usr/lib/systemd/scripts/zswap.sh restart
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
Systemd doesn't have ExecRestart setting as seen from journal:
`systemd[1]: [/usr/lib/systemd/system/zswap.service:8] Unknown lvalue 'ExecRestart' in section 'Service'`
 but ExecReload can be used instead with `systemctl reload`. I think `systemd restart` calls automatically ExecStop and ExecStart.
